### PR TITLE
Stops `So` matching partial words

### DIFF
--- a/write-good/So.yml
+++ b/write-good/So.yml
@@ -2,4 +2,4 @@ extends: existence
 message: "Don't start a sentence with '%s'"
 level: error
 raw:
-  - '(?:[;-]\s)so[\s,]|So[\s,]'
+  - '(?:[;-]\s)so[\s,]|(^|\W)So[\s,]'


### PR DESCRIPTION
Previously it would incorrectly match on sentences like 'The ISO disk contains the data.'.