### PR TITLE
Fixed incorrect link to Travis CI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# write-good [![Build Status](https://travis-ci.org/errata-ai/write-good.svg?branch=master)](https://travis-ci.org/errata-ai/Microsoft) ![Vale version](https://img.shields.io/badge/vale-%3E%3D%20v1.7.0-blue.svg) ![license](https://img.shields.io/github/license/mashape/apistatus.svg)
+# write-good [![Build Status](https://travis-ci.org/errata-ai/write-good.svg?branch=master)](https://travis-ci.org/github/errata-ai/write-good) ![Vale version](https://img.shields.io/badge/vale-%3E%3D%20v1.7.0-blue.svg) ![license](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 > [`write-good`](https://github.com/btford/write-good): Naive linter for English prose for developers who can't write good and wanna learn to do other stuff good too.
 


### PR DESCRIPTION
The build status badge had a target link for different project, `https://travis-ci.org/github/errata-ai/Microsoft`, instead of the build status for this repository, `https://travis-ci.org/github/errata-ai/write-good`. The build status itself was being correctly displayed, but users who clicked the link was led to the incorrect build status.