### PR TITLE
Remove `only` as weasel word

### DIFF
--- a/write-good/Weasel.yml
+++ b/write-good/Weasel.yml
@@ -124,7 +124,6 @@ tokens:
   - normally
   - obediently
   - occasionally
-  - only
   - openly
   - painfully
   - particularly


### PR DESCRIPTION
The "write good" does not consider `only` a weasel word anymore.

See https://github.com/btford/write-good/issues/92

Fixes #11 