### PR TITLE
chore: remove duplicate token in e-prime

### DIFF
--- a/write-good/E-Prime.yml
+++ b/write-good/E-Prime.yml
@@ -11,7 +11,6 @@ tokens:
   - being
   - he's
   - here's
-  - here's
   - how's
   - i'm
   - is


### PR DESCRIPTION
When checking in the styles to my repo, copilot code reviewer caught this duplication and will likely catch it as more users begin using the agent in PR reviews.

